### PR TITLE
Automatically select the new task text to quickly replace it

### DIFF
--- a/edone/gui.py
+++ b/edone/gui.py
@@ -577,6 +577,11 @@ class TasksList(Genlist):
 
         pp.show()
 
+        en.cursor_begin_set()
+        en.cursor_selection_begin()
+        en.cursor_end_set()
+        en.cursor_selection_end()
+
     def _task_edit_end(self, task, entry, popup):
         new_raw = entry.text
         if new_raw:


### PR DESCRIPTION
Hi, I added these few lines because it was very annoying to leave my keyboard to get the mouse when I have a new project in mind. (Yes, I'm a lazy person :p)
